### PR TITLE
Move USB clock control to USB module and added peripheral clock control

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -180,6 +180,8 @@ void HardwareSerial::init(void)
   _serial.tx_buff = _tx_buffer;
   _serial.tx_head = 0;
   _serial.tx_tail = 0;
+  _serial.baudrate = 9600;
+  _config = SERIAL_8N1;
 }
 
 // Actual interrupt handlers //////////////////////////////////////////////////////////////
@@ -221,11 +223,12 @@ int HardwareSerial::_tx_complete_irq(serial_t* obj)
 
 // Public Methods //////////////////////////////////////////////////////////////
 
-void HardwareSerial::begin(unsigned long baud, byte config)
+void HardwareSerial::begin(unsigned long baud, uint8_t config)
 {
   uint32_t databits = 0;
 
   _serial.baudrate = (uint32_t)baud;
+  _config = config;
 
   // Manage databits
   switch(config & 0x07) {

--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -180,7 +180,7 @@ void HardwareSerial::init(void)
   _serial.tx_buff = _tx_buffer;
   _serial.tx_head = 0;
   _serial.tx_tail = 0;
-  _serial.baudrate = 9600;
+  _serial.baudrate = 115200;
   _config = SERIAL_8N1;
 }
 

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -91,6 +91,7 @@ class HardwareSerial : public Stream
   protected:
     // Has any byte been written to the UART since begin()
     bool _written;
+    uint8_t _config;
 
     // Don't put any members after these buffers, since only the first
     // 32 bytes of this struct can be accessed quickly using the ldd
@@ -104,6 +105,7 @@ class HardwareSerial : public Stream
     HardwareSerial(uint32_t _rx, uint32_t _tx);
     HardwareSerial(PinName _rx, PinName _tx);
     HardwareSerial(void* peripheral);
+    void begin() { begin(_serial.baudrate, _config); }
     void begin(unsigned long baud) { begin(baud, SERIAL_8N1); }
     void begin(unsigned long, uint8_t);
     void end();

--- a/cores/arduino/stm32/twi.c
+++ b/cores/arduino/stm32/twi.c
@@ -297,6 +297,31 @@ void i2c_deinit(i2c_t *obj)
   HAL_NVIC_DisableIRQ(obj->irqER);
 #endif // !defined(STM32F0xx) && !defined(STM32L0xx)
   HAL_I2C_DeInit(&(obj->handle));
+
+#if defined I2C1_BASE
+  // Disable I2C1 clock if not done
+  if (obj->i2c == I2C1) {
+    __HAL_RCC_I2C1_CLK_DISABLE();
+  }
+#endif // I2C1_BASE
+#if defined I2C2_BASE
+  // Disable I2C2 clock if not done
+  if (obj->i2c == I2C2) {
+    __HAL_RCC_I2C2_CLK_DISABLE();
+  }
+#endif // I2C2_BASE
+#if defined I2C3_BASE
+  // Disable I2C3 clock if not done
+  if (obj->i2c == I2C3) {
+    __HAL_RCC_I2C3_CLK_DISABLE();
+  }
+#endif // I2C3_BASE
+#if defined I2C4_BASE
+  // Disable I2C4 clock if not done
+  if (obj->i2c == I2C4) {
+    __HAL_RCC_I2C4_CLK_DISABLE();
+  }
+#endif // I2C4_BASE
 }
 
 /**

--- a/cores/arduino/stm32/usb_serial.cpp
+++ b/cores/arduino/stm32/usb_serial.cpp
@@ -53,6 +53,15 @@ USBSerial SerialUSB;
 
 USBSerial::USBSerial(void)
 {
+  m_Started = false;
+}
+
+/* USBSerial is always available and instantiated in main.cpp */
+void USBSerial::begin(void)
+{
+  if (m_Started || ! USBD_LL_ConnectionState())
+    return;
+
   if (USBD_Init(&hUSBD_Device_CDC, &CDC_Desc, DEVICE_FS) == USBD_OK)
   {
 
@@ -66,18 +75,19 @@ USBSerial::USBSerial(void)
 
         /* Start Device Process */
         USBD_Start(&hUSBD_Device_CDC);
+        m_Started = true;
       }
     }
   }
 }
 
-/* USBSerial is always available and instantiated in main.cpp */
-void USBSerial::begin(void)
-{
-}
-
 void USBSerial::end(void)
 {
+  if (m_Started)
+  {
+    m_Started = false;
+    USBD_DeInit(&hUSBD_Device_CDC);
+  }
 }
 
 int USBSerial::availableForWrite(void)
@@ -87,12 +97,20 @@ int USBSerial::availableForWrite(void)
 
 size_t USBSerial::write(uint8_t ch)
 {
-  return CDC_Write(&ch, 1);
+  if (hUSBD_Device_CDC.pClassData)
+    return CDC_Write(&ch, 1);
+
+  m_Started = false;
+  return 1;
 }
 
 size_t USBSerial::write(const uint8_t *buffer, size_t size)
 {
-  return CDC_Write(buffer, size);
+  if (hUSBD_Device_CDC.pClassData)
+    return CDC_Write(buffer, size);
+
+  m_Started = false;
+  return size;
 }
 
 int USBSerial::available(void)
@@ -102,28 +120,45 @@ int USBSerial::available(void)
 
 int USBSerial::read(void)
 {
-  return CDC_Read();
+  if (hUSBD_Device_CDC.pClassData)
+    return CDC_Read();
+
+  m_Started = false;
+  return -1;
 }
 
 int USBSerial::peek(void)
 {
-  return CDC_Peek();
+  if (hUSBD_Device_CDC.pClassData)
+    return CDC_Peek();
+
+  m_Started = false;
+  return -1;
 }
 
 void USBSerial::flush(void)
 {
-  CDC_Flush();
+  if (hUSBD_Device_CDC.pClassData)
+    CDC_Flush();
 }
 
 bool USBSerial::dtr(void)
 {
   uint32_t LineState = CDC_LineState();
+
+  if (LineState == 0)
+    begin();
+
   return LineState & 1;
 }
 
 bool USBSerial::rts(void)
 {
   uint32_t LineState = CDC_LineState();
+
+  if (LineState == 0)
+    begin();
+
   return (LineState & 2) >> 1;
 }
 
@@ -137,9 +172,12 @@ USBSerial::operator bool()
   bool result = false;
   uint32_t LineState = CDC_LineState();
 
+  if (LineState == 0)
+    begin();
+
   if (LineState & 1)
     result = true;
-  delay(10);
+
   return result;
 }
 

--- a/cores/arduino/stm32/usb_serial.cpp
+++ b/cores/arduino/stm32/usb_serial.cpp
@@ -97,6 +97,10 @@ int USBSerial::availableForWrite(void)
 
 size_t USBSerial::write(uint8_t ch)
 {
+  /*
+  || if we haven't lost connection go ahead;
+  || otherwise record that we're not started and claim that we wrote the byte.
+  */
   if (hUSBD_Device_CDC.pClassData)
     return CDC_Write(&ch, 1);
 
@@ -106,6 +110,10 @@ size_t USBSerial::write(uint8_t ch)
 
 size_t USBSerial::write(const uint8_t *buffer, size_t size)
 {
+  /*
+  || if we haven't lost connection go ahead;
+  || otherwise record that we're not started and claim that we wrote the byte.
+  */
   if (hUSBD_Device_CDC.pClassData)
     return CDC_Write(buffer, size);
 
@@ -120,6 +128,7 @@ int USBSerial::available(void)
 
 int USBSerial::read(void)
 {
+  /* if connected, read data; if not, indicate no data, and stop operation. */
   if (hUSBD_Device_CDC.pClassData)
     return CDC_Read();
 
@@ -140,12 +149,15 @@ void USBSerial::flush(void)
 {
   if (hUSBD_Device_CDC.pClassData)
     CDC_Flush();
+  else
+    m_Started = false;
 }
 
 bool USBSerial::dtr(void)
 {
   uint32_t LineState = CDC_LineState();
 
+  /* check if we're connected but not really running. If so, do a begin. */
   if (LineState == 0)
     begin();
 
@@ -156,6 +168,7 @@ bool USBSerial::rts(void)
 {
   uint32_t LineState = CDC_LineState();
 
+  /* check if we're connected but not really running. If so, do a begin. */
   if (LineState == 0)
     begin();
 
@@ -172,6 +185,7 @@ USBSerial::operator bool()
   bool result = false;
   uint32_t LineState = CDC_LineState();
 
+  /* check if we're connected but not really running. If so, do a begin. */
   if (LineState == 0)
     begin();
 

--- a/cores/arduino/stm32/usb_serial.h
+++ b/cores/arduino/stm32/usb_serial.h
@@ -67,6 +67,9 @@ public:
 	bool isConnected();
 
 	virtual operator bool(void);
+
+private:
+	bool	m_Started;
 	};
 
 extern USBSerial SerialUSB;

--- a/variants/CATENA_4551/PeripheralPins.c
+++ b/variants/CATENA_4551/PeripheralPins.c
@@ -37,7 +37,7 @@ Authors:
         STMicroelecronics
         ChaeHee Won, MCCI Corporation
 
- */
+*/
 
 #include "Arduino.h"
 #include "PeripheralPins.h"

--- a/variants/CATENA_4551/usb/usbd_cdc_if.c
+++ b/variants/CATENA_4551/usb/usbd_cdc_if.c
@@ -166,6 +166,10 @@ static int8_t CDC_Init_FS(void)
   */
 static int8_t CDC_DeInit_FS(void)
 {
+  UserTxBufPtrIn = 0;
+  UserRxBufPtrIn = 0;
+  UserRxBufPtrOut = 0;
+  gCDC_LineState = 0;
   return (USBD_OK);
 }
 

--- a/variants/CATENA_4551/variant.cpp
+++ b/variants/CATENA_4551/variant.cpp
@@ -199,7 +199,7 @@ void SystemClock_Config(void)
   LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 #endif
 
-#ifdef USBCON
+#if 0	/* Move clock setting code to usbd_conf.c */
     /**Enable the SYSCFG APB clock
     */
   __HAL_RCC_CRS_CLK_ENABLE();

--- a/variants/CATENA_461x/usb/usbd_cdc_if.c
+++ b/variants/CATENA_461x/usb/usbd_cdc_if.c
@@ -166,6 +166,10 @@ static int8_t CDC_Init_FS(void)
   */
 static int8_t CDC_DeInit_FS(void)
 {
+  UserTxBufPtrIn = 0;
+  UserRxBufPtrIn = 0;
+  UserRxBufPtrOut = 0;
+  gCDC_LineState = 0;
   return (USBD_OK);
 }
 

--- a/variants/CATENA_461x/usb/usbd_conf.c
+++ b/variants/CATENA_461x/usb/usbd_conf.c
@@ -73,6 +73,22 @@ PCD_HandleTypeDef g_hpcd;
 void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
 {
   GPIO_InitTypeDef  GPIO_InitStruct;
+  RCC_CRSInitTypeDef RCC_CRSInitStruct;
+
+  __HAL_RCC_HSI48_ENABLE();
+
+  /* Enable the SYSCFG APB clock */
+  __HAL_RCC_CRS_CLK_ENABLE();
+
+  /* Configures CRS */
+  RCC_CRSInitStruct.Prescaler = RCC_CRS_SYNC_DIV1;
+  RCC_CRSInitStruct.Source = RCC_CRS_SYNC_SOURCE_USB;
+  RCC_CRSInitStruct.Polarity = RCC_CRS_SYNC_POLARITY_RISING;
+  RCC_CRSInitStruct.ReloadValue = __HAL_RCC_CRS_RELOADVALUE_CALCULATE(48000000,1000);
+  RCC_CRSInitStruct.ErrorLimitValue = 34;
+  RCC_CRSInitStruct.HSI48CalibrationValue = 32;
+
+  HAL_RCCEx_CRSConfig(&RCC_CRSInitStruct);
 
 //  __HAL_RCC_SYSCFG_CLK_ENABLE();
   __HAL_RCC_PWR_CLK_ENABLE();
@@ -108,8 +124,24 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
   */
 void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd)
 {
+  HAL_NVIC_DisableIRQ(USB_IRQn);
+
   /* Disable USB FS Clock */
+  __HAL_RCC_USB_FORCE_RESET();
+  __HAL_RCC_USB_RELEASE_RESET();
   __HAL_RCC_USB_CLK_DISABLE();
+
+  __HAL_RCC_PWR_CLK_SLEEP_ENABLE();
+
+  __HAL_RCC_PWR_CLK_DISABLE();
+
+  CLEAR_BIT(CRS->CR, (CRS_CR_AUTOTRIMEN | CRS_CR_CEN));
+  __HAL_RCC_CRS_FORCE_RESET();
+  __HAL_RCC_CRS_RELEASE_RESET();
+  __HAL_RCC_CRS_CLK_DISABLE();
+
+  __HAL_RCC_HSI48_DISABLE();
+  __HAL_RCC_SYSCFG_CLK_DISABLE();
 }
 
 /*******************************************************************************
@@ -210,6 +242,12 @@ void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd)
     /* Set SLEEPDEEP bit and SleepOnExit of Cortex System Control Register */
     //SCB->SCR |= (uint32_t)((uint32_t)(SCB_SCR_SLEEPDEEP_Msk | SCB_SCR_SLEEPONEXIT_Msk));
   }
+
+  if (! USBD_LL_ConnectionState())
+  {
+    USBD_UsrLog("USB suspend: no USB power");
+    USBD_DeInit(hpcd->pData);
+  }
 }
 
 /**
@@ -292,6 +330,8 @@ void USB_IRQHandler(void)
 USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
 {
   /* Set LL Driver parameters */
+  USBD_memset(&g_hpcd, 0, sizeof(g_hpcd));
+
   g_hpcd.Instance = USB;
   g_hpcd.Init.dev_endpoints = 8;
   g_hpcd.Init.speed = PCD_SPEED_FULL;
@@ -307,20 +347,25 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
   /* Initialize LL Driver */
   HAL_PCD_Init(&g_hpcd);
 
-  HAL_PCDEx_PMAConfig(pdev->pData, 0x00, PCD_SNG_BUF, 0x10);
-  HAL_PCDEx_PMAConfig(pdev->pData, 0x80, PCD_SNG_BUF, 0x50);
+  HAL_PCDEx_PMAConfig(&g_hpcd, 0x00, PCD_SNG_BUF, 0x10);
+  HAL_PCDEx_PMAConfig(&g_hpcd, 0x80, PCD_SNG_BUF, 0x50);
 
-//  HAL_PCDEx_PMAConfig(pdev->pData, 0x01, PCD_DBL_BUF, 0x01400100);
-//  HAL_PCDEx_PMAConfig(pdev->pData, 0x81, PCD_DBL_BUF, 0x01C00180);
-  HAL_PCDEx_PMAConfig(pdev->pData, 0x01, PCD_SNG_BUF, 0x0100);
-  HAL_PCDEx_PMAConfig(pdev->pData, 0x81, PCD_SNG_BUF, 0x0180);
+//  HAL_PCDEx_PMAConfig(&g_hpcd, 0x01, PCD_DBL_BUF, 0x01400100);
+//  HAL_PCDEx_PMAConfig(&g_hpcd, 0x81, PCD_DBL_BUF, 0x01C00180);
+  HAL_PCDEx_PMAConfig(&g_hpcd, 0x01, PCD_SNG_BUF, 0x0100);
+  HAL_PCDEx_PMAConfig(&g_hpcd, 0x81, PCD_SNG_BUF, 0x0180);
 
-  HAL_PCDEx_PMAConfig(pdev->pData, 0x02, PCD_SNG_BUF, 0x0200);
-  HAL_PCDEx_PMAConfig(pdev->pData, 0x82, PCD_SNG_BUF, 0x0280);
+  HAL_PCDEx_PMAConfig(&g_hpcd, 0x02, PCD_SNG_BUF, 0x0200);
+  HAL_PCDEx_PMAConfig(&g_hpcd, 0x82, PCD_SNG_BUF, 0x0280);
 
-//  HAL_PCDEx_PMAConfig(pdev->pData, 0x03, PCD_SNG_BUF, 0x0300);
-//  HAL_PCDEx_PMAConfig(pdev->pData, 0x83, PCD_SNG_BUF, 0x0380);
+//  HAL_PCDEx_PMAConfig(&g_hpcd, 0x03, PCD_SNG_BUF, 0x0300);
+//  HAL_PCDEx_PMAConfig(&g_hpcd, 0x83, PCD_SNG_BUF, 0x0380);
 
+  USBD_UsrLog("USBD_LL_Init: CNTR=%04x ISTR=%04x CRRCR=%08x CCIPR=%08x",
+  	      g_hpcd.Instance->CNTR,
+  	      g_hpcd.Instance->ISTR,
+  	      RCC->CRRCR,
+  	      RCC->CCIPR);
   return USBD_OK;
 }
 
@@ -353,6 +398,9 @@ USBD_StatusTypeDef USBD_LL_Start(USBD_HandleTypeDef *pdev)
   */
 USBD_StatusTypeDef USBD_LL_Stop(USBD_HandleTypeDef *pdev)
 {
+  USBD_UsrLog("USBD_LL_Stop: CNTR=%04x ISTR=%04x",
+  	      g_hpcd.Instance->CNTR,
+  	      g_hpcd.Instance->ISTR);
   HAL_PCD_Stop(pdev->pData);
   return USBD_OK;
 }
@@ -541,7 +589,7 @@ uint32_t USBD_LL_ConnectionState(void)
   uint32_t vBus;
 
   vBus = analogRead(18);
-  return vBus > 500 ? 1 : 0;
+  return vBus > 250 ? 1 : 0;
 }
 
 #endif // USBCON

--- a/variants/CATENA_461x/variant.cpp
+++ b/variants/CATENA_461x/variant.cpp
@@ -200,7 +200,7 @@ void SystemClock_Config(void)
   LL_RCC_SetClkAfterWakeFromStop(LL_RCC_STOP_WAKEUPCLOCK_HSI);
 #endif
 
-#ifdef USBCON
+#if 0	/* Move clock setting code to usbd_conf.c */
     /**Enable the SYSCFG APB clock
     */
   __HAL_RCC_CRS_CLK_ENABLE();


### PR DESCRIPTION
I added peripheral module clock controls. It turn off peripheral clock when class end method called.
I moved USB clock settings from SystemClock_Config() to USB driver. So USB serial class begin and end methods can turn on and off USB clocks.
