### PR TITLE
Fix #73: Enable HAL_RCC_PWR_CLK, PWR_LOWPOWERREGULATOR_ON, PWR_CR_ULP

### DIFF
--- a/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pwr.c
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pwr.c
@@ -611,7 +611,7 @@ static void HAL_PWR_RestoreCFGR(uint32_t save_rcc_cfgr)
     {
       /* Wait for PLL ready */
     }
-    
+
     RCC->CFGR = save_rcc_cfgr;
 
     while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_PLL)
@@ -639,6 +639,18 @@ void HAL_PWR_EnterSTANDBYMode(void)
   uint32_t const save_rcc_cfgr = RCC->CFGR;
   uint32_t const save_pwr_cr = PWR->CR;
 
+  /* Enable Power interface clock */
+  __HAL_RCC_PWR_CLK_ENABLE();
+
+  /* Enable the low power voltage regulator */
+  SET_BIT(PWR->CR, PWR_LOWPOWERREGULATOR_ON);
+
+  /* Set Ultra-Low-power mode by switch-off Vrefint */
+  SET_BIT(PWR->CR, PWR_CR_ULP);
+
+  /* Clear WUF flag */
+  __HAL_PWR_CLEAR_FLAG(PWR_FLAG_WU);
+
   /* Select Standby mode */
   SET_BIT(PWR->CR, PWR_CR_PDDS);
 
@@ -664,6 +676,9 @@ void HAL_PWR_EnterSTANDBYMode(void)
   /* restore the register we stuffed */
   PWR->CR = save_pwr_cr;
   HAL_PWR_RestoreCFGR(save_rcc_cfgr);
+
+  /* Disable Power interface clock */
+  __HAL_RCC_PWR_CLK_DISABLE();
 }
 
 /**


### PR DESCRIPTION
On enabling HAL_RCC_PWR_CLK, PWR_LOWPOWERREGULATOR_ON, PWR_CR_ULP in Standby mode, power is reduced for STM32 devices.

We have tested the changes with Catena 4801 and 4612, the sleep power is 4.2 uA and 24 uA respectively.