### PR TITLE
Fix #76: Enable HAL_RCC_PWR_CLK, PWR_LOWPOWERREGULATOR_ON, PWR_CR_ULP

### DIFF
--- a/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pwr.c
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pwr.c
@@ -651,18 +651,6 @@ void HAL_PWR_EnterSTANDBYMode(void)
   uint32_t const save_rcc_cfgr = RCC->CFGR;
   uint32_t const save_pwr_cr = PWR->CR;
 
-  /* Enable Power interface clock */
-  __HAL_RCC_PWR_CLK_ENABLE();
-
-  /* Enable the low power voltage regulator */
-  SET_BIT(PWR->CR, PWR_LOWPOWERREGULATOR_ON);
-
-  /* Set Ultra-Low-power mode by switch-off Vrefint */
-  SET_BIT(PWR->CR, PWR_CR_ULP);
-
-  /* Clear WUF flag */
-  __HAL_PWR_CLEAR_FLAG(PWR_FLAG_WU);
-
   /* Select Standby mode */
   SET_BIT(PWR->CR, PWR_CR_PDDS);
 
@@ -688,9 +676,6 @@ void HAL_PWR_EnterSTANDBYMode(void)
   /* restore the register we stuffed */
   PWR->CR = save_pwr_cr;
   HAL_PWR_RestoreCFGR(save_rcc_cfgr);
-
-  /* Disable Power interface clock */
-  __HAL_RCC_PWR_CLK_DISABLE();
 }
 
 /**

--- a/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pwr.c
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pwr.c
@@ -553,9 +553,6 @@ void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry)
   uint32_t const save_syscfg_cfgr3 = SYSCFG->CFGR3;
   uint32_t tmpreg;
 
-  /* Enable the low power voltage regulator */
-  SET_BIT(PWR->CR, PWR_LOWPOWERREGULATOR_ON);
-
   /* Set Ultra-Low-power mode by switch-off Vrefint */
   SET_BIT(PWR->CR, PWR_CR_ULP);
 

--- a/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pwr.c
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pwr.c
@@ -545,10 +545,22 @@ void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry)
   */
 void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry)
 {
+  /* Enable Power interface clock */
+  __HAL_RCC_PWR_CLK_ENABLE();
+
   uint32_t const save_rcc_cfgr = RCC->CFGR;
   uint32_t const save_pwr_cr = PWR->CR;
   uint32_t const save_syscfg_cfgr3 = SYSCFG->CFGR3;
   uint32_t tmpreg;
+
+  /* Enable the low power voltage regulator */
+  SET_BIT(PWR->CR, PWR_LOWPOWERREGULATOR_ON);
+
+  /* Set Ultra-Low-power mode by switch-off Vrefint */
+  SET_BIT(PWR->CR, PWR_CR_ULP);
+
+  /* Clear WUF flag */
+  __HAL_PWR_CLEAR_FLAG(PWR_FLAG_WU);
 
   /* Check the parameters */
   assert_param(IS_PWR_REGULATOR(Regulator));
@@ -599,6 +611,9 @@ void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry)
   PWR->CR = save_pwr_cr;
   SYSCFG->CFGR3 = save_syscfg_cfgr3;
   HAL_PWR_RestoreCFGR(save_rcc_cfgr);
+
+  /* Disable Power interface clock */
+  __HAL_RCC_PWR_CLK_DISABLE();
 }
 
 static void HAL_PWR_RestoreCFGR(uint32_t save_rcc_cfgr)


### PR DESCRIPTION
On enabling HAL_RCC_PWR_CLK, PWR_LOWPOWERREGULATOR_ON, PWR_CR_ULP in StopWithLowPowerRegulator mode, power is reduced for STM32 devices. Please find the average sleep power consumption for Catena devices below:

| Device name | Power Consumption |
| ------------- | ------------- |
| Catena 4612 | 21.8 uA |
| Catena 4801 | 5.15 uA |