### PR TITLE
Power-management cleanups

### DIFF
--- a/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_pwr.h
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_pwr.h
@@ -54,7 +54,7 @@
 
 /** @defgroup PWR_Exported_Types PWR Exported Types
   * @{
-  */ 
+  */
 
 /**
   * @brief  PWR PVD configuration structure definition
@@ -74,7 +74,7 @@ typedef struct
 
 /** @addtogroup PWR_Private
   * @{
-  */ 
+  */
 
 #define PWR_EXTI_LINE_PVD      EXTI_FTSR_TR16  /*!< External interrupt line 16 Connected to the PVD EXTI Line */
 
@@ -109,7 +109,7 @@ typedef struct
 #define PWR_PVDLEVEL_4                 PWR_CR_PLS_LEV4
 #define PWR_PVDLEVEL_5                 PWR_CR_PLS_LEV5
 #define PWR_PVDLEVEL_6                 PWR_CR_PLS_LEV6
-#define PWR_PVDLEVEL_7                 PWR_CR_PLS_LEV7  /* External input analog voltage 
+#define PWR_PVDLEVEL_7                 PWR_CR_PLS_LEV7  /* External input analog voltage
                                                            (Compare internally to VREFINT) */
 /**
   * @}
@@ -197,8 +197,8 @@ typedef struct
   */
 /** @brief  macros configure the main internal regulator output voltage.
   *         When exiting Low Power Run Mode or during dynamic voltage scaling configuration,
-  *         the reference manual recommends to poll PWR_FLAG_REGLP bit to wait for the regulator 
-  *         to reach main mode (resp. to get stabilized) for a transition from 0 to 1. 
+  *         the reference manual recommends to poll PWR_FLAG_REGLP bit to wait for the regulator
+  *         to reach main mode (resp. to get stabilized) for a transition from 0 to 1.
   *         Only then the clock can be increased.
   *
   * @param  __REGULATOR__: specifies the regulator output voltage to achieve
@@ -225,7 +225,7 @@ typedef struct
   *                  (by setting the EWUP bit) when the WKUP pin level is already high.
   *            @arg PWR_FLAG_SB: StandBy flag. This flag indicates that the system was
   *                  resumed from StandBy mode.
-  *            @arg PWR_FLAG_PVDO: PVD Output. This flag is valid only if PVD is enabled 
+  *            @arg PWR_FLAG_PVDO: PVD Output. This flag is valid only if PVD is enabled
   *                  by the HAL_PWR_EnablePVD() function. The PVD is stopped by Standby mode.
   *                  For this reason, this bit is equal to 0 after Standby or reset
   *                  until the PVDE bit is set.
@@ -258,7 +258,7 @@ typedef struct
 #define __HAL_PWR_PVD_EXTI_ENABLE_IT()      SET_BIT(EXTI->IMR, PWR_EXTI_LINE_PVD)
 
 /**
-  * @brief Disable interrupt on PVD Exti Line 16. 
+  * @brief Disable interrupt on PVD Exti Line 16.
   * @retval None.
   */
 #define __HAL_PWR_PVD_EXTI_DISABLE_IT()     CLEAR_BIT(EXTI->IMR, PWR_EXTI_LINE_PVD)
@@ -277,7 +277,7 @@ typedef struct
 
 
 /**
-  * @brief  PVD EXTI line configuration: set falling edge trigger.  
+  * @brief  PVD EXTI line configuration: set falling edge trigger.
   * @retval None.
   */
 #define __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE()  SET_BIT(EXTI->FTSR, PWR_EXTI_LINE_PVD)
@@ -357,7 +357,7 @@ typedef struct
 #define IS_PWR_PVD_MODE(MODE) (((MODE) == PWR_PVD_MODE_IT_RISING)|| ((MODE) == PWR_PVD_MODE_IT_FALLING) || \
                               ((MODE) == PWR_PVD_MODE_IT_RISING_FALLING) || ((MODE) == PWR_PVD_MODE_EVENT_RISING) || \
                               ((MODE) == PWR_PVD_MODE_EVENT_FALLING) || ((MODE) == PWR_PVD_MODE_EVENT_RISING_FALLING) || \
-                              ((MODE) == PWR_PVD_MODE_NORMAL)) 
+                              ((MODE) == PWR_PVD_MODE_NORMAL))
 
 #if defined (STM32L071xx) || defined (STM32L072xx) || defined (STM32L073xx) || defined (STM32L081xx) || defined (STM32L082xx) || defined (STM32L083xx)
 #define IS_PWR_WAKEUP_PIN(PIN) (((PIN) == PWR_WAKEUP_PIN1) || \
@@ -390,8 +390,8 @@ typedef struct
 /** @defgroup PWR_Exported_Functions PWR Exported Functions
   * @{
   */
-  
-/** @defgroup PWR_Exported_Functions_Group1 Initialization and de-initialization functions 
+
+/** @defgroup PWR_Exported_Functions_Group1 Initialization and de-initialization functions
   * @{
   */
 void HAL_PWR_DeInit(void);
@@ -454,7 +454,7 @@ void HAL_PWR_ResetWakeupFlag(void);
 /**
   * @}
   */
-  
+
 #ifdef __cplusplus
 }
 #endif

--- a/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_pwr.h
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_pwr.h
@@ -427,6 +427,8 @@ void HAL_PWR_DisableSleepOnExit(void);
 void HAL_PWR_EnableSEVOnPend(void);
 void HAL_PWR_DisableSEVOnPend(void);
 
+void HAL_PWR_ResetWakeupFlag(void);
+
 /**
   * @}
   */

--- a/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_pwr.h
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_pwr.h
@@ -420,6 +420,7 @@ void HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx);
 void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry);
 void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry);
 void HAL_PWR_EnterSTANDBYMode(void);
+void HAL_PWR_EnterTrueSTANDBYMode(void) __attribute__((noreturn));
 
 void HAL_PWR_EnableSleepOnExit(void);
 void HAL_PWR_DisableSleepOnExit(void);

--- a/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_rtc.h
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_rtc.h
@@ -476,23 +476,19 @@ typedef struct
 /**
   * @brief  Disable the write protection for RTC registers.
   * @param  __HANDLE__: specifies the RTC handle.
-  * @retval None
+  * @retval non-zero: global background protection was previously enabled.
   */
 #define __HAL_RTC_WRITEPROTECTION_DISABLE(__HANDLE__)             \
-                        do{                                       \
-                            (__HANDLE__)->Instance->WPR = 0xCAU;   \
-                            (__HANDLE__)->Instance->WPR = 0x53U;   \
-                          } while(0U)
+                        RTC_DisableWriteProtection(__HANDLE__)
 
 /**
   * @brief  Enable the write protection for RTC registers.
   * @param  __HANDLE__: specifies the RTC handle.
   * @retval None
+  * @note   This function always clears the DBP bit in PWR->CR.
   */
 #define __HAL_RTC_WRITEPROTECTION_ENABLE(__HANDLE__)              \
-                        do{                                       \
-                            (__HANDLE__)->Instance->WPR = 0xFFU;   \
-                          } while(0U)
+                        RTC_EnableWriteProtection(__HANDLE__, 1)
 
 /**
   * @brief  Enable the RTC ALARMA peripheral.
@@ -881,6 +877,9 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
 HAL_StatusTypeDef  RTC_EnterInitMode(RTC_HandleTypeDef* hrtc);
 uint8_t            RTC_ByteToBcd2(uint8_t Value);
 uint8_t            RTC_Bcd2ToByte(uint8_t Value);
+int                RTC_DisableWriteProtection(RTC_HandleTypeDef* hrtc);
+void               RTC_EnableWriteProtection(RTC_HandleTypeDef* hrtc, int dbp);
+
 /**
   * @}
   */

--- a/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_rtc.h
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_rtc.h
@@ -52,13 +52,13 @@
   * @{
   */
 
-/* Exported types ------------------------------------------------------------*/ 
+/* Exported types ------------------------------------------------------------*/
 /** @defgroup RTC_Exported_Types RTC Exported Types
   * @{
   */
 
-/** 
-  * @brief  HAL State structures definition  
+/**
+  * @brief  HAL State structures definition
   */
 typedef enum
 {
@@ -70,7 +70,7 @@ typedef enum
 
 }HAL_RTCStateTypeDef;
 
-/** 
+/**
   * @brief  RTC Configuration Structure definition
   */
 typedef struct
@@ -80,7 +80,7 @@ typedef struct
 
   uint32_t AsynchPrediv;    /*!< Specifies the RTC Asynchronous Predivider value.
                                  This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7F */
-                               
+
   uint32_t SynchPrediv;     /*!< Specifies the RTC Synchronous Predivider value.
                                  This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7FFF */
 
@@ -90,15 +90,15 @@ typedef struct
   uint32_t OutPutRemap;    /*!< Specifies the remap for RTC output.
                                  This parameter can be a value of @ref  RTC_Output_ALARM_OUT_Remap */
 
-  uint32_t OutPutPolarity;  /*!< Specifies the polarity of the output signal.  
+  uint32_t OutPutPolarity;  /*!< Specifies the polarity of the output signal.
                                  This parameter can be a value of @ref RTC_Output_Polarity_Definitions */
 
   uint32_t OutPutType;      /*!< Specifies the RTC Output Pin mode.
                                  This parameter can be a value of @ref RTC_Output_Type_ALARM_OUT */
 }RTC_InitTypeDef;
 
-/** 
-  * @brief  RTC Time structure definition  
+/**
+  * @brief  RTC Time structure definition
   */
 typedef struct
 {
@@ -114,26 +114,26 @@ typedef struct
 
   uint8_t TimeFormat;       /*!< Specifies the RTC AM/PM Time.
                                  This parameter can be a value of @ref RTC_AM_PM_Definitions */
-  
+
   uint32_t SubSeconds;     /*!< Specifies the RTC_SSR RTC Sub Second register content.
                                  This parameter corresponds to a time unit range between [0-1] Second
                                  with [1 Sec / SecondFraction +1] granularity */
- 
+
   uint32_t SecondFraction;  /*!< Specifies the range or granularity of Sub Second register content
                                  corresponding to Synchronous pre-scaler factor value (PREDIV_S)
                                  This parameter corresponds to a time unit range between [0-1] Second
                                  with [1 Sec / SecondFraction +1] granularity.
                                  This field will be used only by HAL_RTC_GetTime function */
-  
+
   uint32_t DayLightSaving;  /*!< Specifies RTC_DayLightSaveOperation: the value of hour adjustment.
                                  This parameter can be a value of @ref RTC_DayLightSaving_Definitions */
 
-  uint32_t StoreOperation;  /*!< Specifies RTC_StoreOperation value to be written in the BCK bit 
+  uint32_t StoreOperation;  /*!< Specifies RTC_StoreOperation value to be written in the BCK bit
                                  in CR register to store the operation.
                                  This parameter can be a value of @ref RTC_StoreOperation_Definitions */
 }RTC_TimeTypeDef;
 
-/** 
+/**
   * @brief  RTC Date structure definition
   */
 typedef struct
@@ -152,7 +152,7 @@ typedef struct
 
 }RTC_DateTypeDef;
 
-/** 
+/**
   * @brief  RTC Alarm structure definition
   */
 typedef struct
@@ -161,7 +161,7 @@ typedef struct
 
   uint32_t AlarmMask;            /*!< Specifies the RTC Alarm Masks.
                                       This parameter can be a value of @ref RTC_AlarmMask_Definitions */
-  
+
   uint32_t AlarmSubSecondMask;   /*!< Specifies the RTC Alarm SubSeconds Masks.
                                       This parameter can be a value of @ref RTC_Alarm_Sub_Seconds_Masks_Definitions */
 
@@ -176,9 +176,9 @@ typedef struct
                                       This parameter can be a value of @ref RTC_Alarms_Definitions */
 }RTC_AlarmTypeDef;
 
-/** 
-  * @brief  RTC Handle Structure definition  
-  */ 
+/**
+  * @brief  RTC Handle Structure definition
+  */
 typedef struct
 {
   RTC_TypeDef               *Instance;  /*!< Register base address    */
@@ -198,7 +198,7 @@ typedef struct
 /** @defgroup RTC_Exported_Constants RTC Exported Constants
   * @{
   */
- 
+
 /** @defgroup RTC_Hour_Formats RTC Hour Formats
   * @{
   */
@@ -238,7 +238,7 @@ typedef struct
 /**
   * @}
   */
-  
+
 /** @defgroup RTC_AM_PM_Definitions RTC AM PM Definitions
   * @{
   */
@@ -611,31 +611,31 @@ typedef struct
 #define __HAL_RTC_ALARM_EXTI_DISABLE_EVENT()         (EXTI->EMR &= ~(RTC_EXTI_LINE_ALARM_EVENT))
 
 /**
-  * @brief  Enable falling edge trigger on the RTC Alarm associated Exti line.  
+  * @brief  Enable falling edge trigger on the RTC Alarm associated Exti line.
   * @retval None.
   */
 #define __HAL_RTC_ALARM_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR |= RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief  Disable falling edge trigger on the RTC Alarm associated Exti line.  
+  * @brief  Disable falling edge trigger on the RTC Alarm associated Exti line.
   * @retval None.
   */
 #define __HAL_RTC_ALARM_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR &= ~(RTC_EXTI_LINE_ALARM_EVENT))
 
 /**
-  * @brief  Enable rising edge trigger on the RTC Alarm associated Exti line.  
+  * @brief  Enable rising edge trigger on the RTC Alarm associated Exti line.
   * @retval None.
   */
 #define __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR |= RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief  Disable rising edge trigger on the RTC Alarm associated Exti line.  
+  * @brief  Disable rising edge trigger on the RTC Alarm associated Exti line.
   * @retval None.
   */
 #define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR &= ~(RTC_EXTI_LINE_ALARM_EVENT))
 
 /**
-  * @brief  Enable rising & falling edge trigger on the RTC Alarm associated Exti line.  
+  * @brief  Enable rising & falling edge trigger on the RTC Alarm associated Exti line.
   * @retval None.
   */
 #define __HAL_RTC_ALARM_EXTI_ENABLE_RISING_FALLING_EDGE()  do { \
@@ -644,7 +644,7 @@ typedef struct
                                                            } while(0U)
 
 /**
-  * @brief  Disable rising & falling edge trigger on the RTC Alarm associated Exti line.  
+  * @brief  Disable rising & falling edge trigger on the RTC Alarm associated Exti line.
   * @retval None.
   */
 #define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_FALLING_EDGE() do { \
@@ -723,7 +723,7 @@ void              HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc);
 
 /** @defgroup  RTC_Exported_Functions_Group4 Peripheral Control functions
   * @{
-  */  
+  */
 /* Peripheral Control functions ***********************************************/
 HAL_StatusTypeDef   HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc);
 /**
@@ -732,7 +732,7 @@ HAL_StatusTypeDef   HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc);
 
 /** @defgroup RTC_Exported_Functions_Group5 Peripheral State functions
   * @{
-  */  
+  */
 /* Peripheral State functions *************************************************/
 HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
 /**
@@ -741,9 +741,9 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
 
 /**
   * @}
-  */  
+  */
 
-/* Private types -------------------------------------------------------------*/ 
+/* Private types -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private constants ---------------------------------------------------------*/
 /** @defgroup RTC_Private_Constants RTC Private Constants
@@ -760,7 +760,7 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
 #define RTC_RSF_MASK            ((uint32_t)~(RTC_ISR_INIT | RTC_ISR_RSF))
 
 #define RTC_TIMEOUT_VALUE  1000U
-  
+
 #define RTC_EXTI_LINE_ALARM_EVENT             ((uint32_t)EXTI_IMR_IM17)  /*!< External interrupt line 17 Connected to the RTC Alarm event */
 
 /**
@@ -774,7 +774,7 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
 
 /** @defgroup RTC_IS_RTC_Definitions RTC Private macros to check input parameters
   * @{
-  */ 
+  */
 
 #define IS_RTC_HOUR_FORMAT(FORMAT)     (((FORMAT) == RTC_HOURFORMAT_12) || \
                                         ((FORMAT) == RTC_HOURFORMAT_24))
@@ -869,7 +869,7 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
 /**
   * @}
   */
-  
+
 /* Private functions -------------------------------------------------------------*/
 /** @defgroup RTC_Private_Functions RTC Private Functions
   * @{
@@ -883,7 +883,7 @@ void               RTC_EnableWriteProtection(RTC_HandleTypeDef* hrtc, int dbp);
 /**
   * @}
   */
-  
+
 
 /**
   * @}

--- a/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pwr.c
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pwr.c
@@ -791,6 +791,28 @@ void HAL_PWR_DisableSEVOnPend(void)
 }
 
 /**
+  * @brief Reset the wakeup flag
+  * @note The PWR->CSR WUF, if set, will cause an immediate return from
+  *       STANDBY. It's not cleared by system reset. So, prior to setting
+  *       up a wakeup event, it's a good idea to clear it (otherwise you
+  *       will reboot immediately when you try to enter STANDBY).
+  * @retval None
+  */
+void HAL_PWR_ResetWakeupFlag(void)
+{
+  uint32_t const save_rcc_apb1enr = RCC->APB1ENR;
+  uint32_t const save_pwr_cr = PWR->CR;
+
+  /* turn on the clock to the power registers */
+  RCC->APB1ENR = save_rcc_apb1enr | RCC_APB1ENR_PWREN;
+
+  PWR->CR = save_pwr_cr | PWR_CR_CWUF;
+
+  /* now turn off the clock to power registers */
+  RCC->APB1ENR = save_rcc_apb1enr;
+}
+
+/**
   * @brief This function handles the PWR PVD interrupt request.
   * @note This API should be called under the PVD_IRQHandler().
   * @retval None

--- a/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_rtc.c
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_rtc.c
@@ -9,28 +9,28 @@
   *           + I/O operation functions
   *           + Peripheral Control functions
   *           + Peripheral State functions
-  *         
+  *
   @verbatim
   ==============================================================================
               ##### Backup Domain Operating Condition #####
   ==============================================================================
-  [..] As long as the supply voltage remains in the operating range, 
-       the RTC never stops, regardless of the device status (Run mode, 
+  [..] As long as the supply voltage remains in the operating range,
+       the RTC never stops, regardless of the device status (Run mode,
        low power modes or under reset).
 
                    ##### Backup Domain Reset #####
   ==================================================================
-  [..] The backup domain reset sets all RTC registers and the RCC_CSR register 
+  [..] The backup domain reset sets all RTC registers and the RCC_CSR register
        to their reset values.
   [..] A backup domain reset is generated when one of the following events occurs:
-    (+) Software reset, triggered by setting the RTCRST bit in the 
+    (+) Software reset, triggered by setting the RTCRST bit in the
         RCC Control Status register (RCC_CSR).
     (+) Power reset (BOR/POR/PDR).
 
                    ##### Backup Domain Access #####
   ==================================================================
-  [..] After reset, the backup domain (RTC registers and RTC backup data registers) 
-       is protected against possible unwanted write accesses. 
+  [..] After reset, the backup domain (RTC registers and RTC backup data registers)
+       is protected against possible unwanted write accesses.
   [..] To enable access to the RTC Domain and RTC registers, proceed as follows:
     (+) Enable the Power Controller (PWR) APB1 interface clock using the
         __HAL_RCC_PWR_CLK_ENABLE() function.
@@ -48,7 +48,7 @@
 
   *** Time and Date configuration ***
   ===================================
-  [..] 
+  [..]
     (+) To configure the RTC Calendar (Time and Date) use the HAL_RTC_SetTime()
         and HAL_RTC_SetDate() functions.
     (+) To read the RTC Calendar, use the HAL_RTC_GetTime() and HAL_RTC_GetDate() functions.
@@ -57,7 +57,7 @@
   ===========================
   [..]
     (+) To configure the RTC Alarm use the HAL_RTC_SetAlarm() function.
-            You can also configure the RTC Alarm with interrupt mode using the 
+            You can also configure the RTC Alarm with interrupt mode using the
             HAL_RTC_SetAlarm_IT() function.
     (+) To read the RTC Alarm, use the HAL_RTC_GetAlarm() function.
 
@@ -67,7 +67,7 @@
        function.
   [..] The RTC alternate functions are the RTC alarms (Alarm A and Alarm B),
        RTC wakeup, RTC tamper event detection and RTC time stamp event detection.
-       These RTC alternate functions can wake up the system from the Stop and 
+       These RTC alternate functions can wake up the system from the Stop and
        Standby low power modes.
   [..] The system can also wake up from low power modes without depending
        on an external interrupt (Auto-wakeup mode), by using the RTC alarm
@@ -105,7 +105,7 @@
   * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   *
-  ******************************************************************************  
+  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -135,33 +135,33 @@
   */
 
 /** @addtogroup RTC_Exported_Functions_Group1
- *  @brief    Initialization and Configuration functions 
+ *  @brief    Initialization and Configuration functions
  *
 @verbatim
  ===============================================================================
               ##### Initialization and de-initialization functions #####
  ===============================================================================
-   [..] This section provides functions allowing to initialize and configure the 
-         RTC Prescaler (Synchronous and Asynchronous), RTC Hour format, disable 
+   [..] This section provides functions allowing to initialize and configure the
+         RTC Prescaler (Synchronous and Asynchronous), RTC Hour format, disable
          RTC registers Write protection, enter and exit the RTC initialization mode,
          RTC registers synchronization check and reference clock detection enable.
          (#) The RTC Prescaler is programmed to generate the RTC 1Hz time base.
              It is split into 2 programmable prescalers to minimize power consumption.
              (++) A 7-bit asynchronous prescaler and a 15-bit synchronous prescaler.
-             (++) When both prescalers are used, it is recommended to configure the 
+             (++) When both prescalers are used, it is recommended to configure the
                  asynchronous prescaler to a high value to minimize power consumption.
          (#) All RTC registers are Write protected. Writing to the RTC registers
              is enabled by writing a key into the Write Protection register, RTC_WPR.
-         (#) To configure the RTC Calendar, user application should enter 
+         (#) To configure the RTC Calendar, user application should enter
              initialization mode. In this mode, the calendar counter is stopped
-             and its value can be updated. When the initialization sequence is 
+             and its value can be updated. When the initialization sequence is
              complete, the calendar restarts counting after 4 RTCCLK cycles.
-         (#) To read the calendar through the shadow registers after Calendar 
+         (#) To read the calendar through the shadow registers after Calendar
              initialization, calendar update or after wakeup from low power modes
              the software must first clear the RSF flag. The software must then
              wait until it is set again before reading the calendar, which means
              that the calendar registers have been correctly copied into the
-             RTC_TR and RTC_DR shadow registers.The HAL_RTC_WaitForSynchro() function 
+             RTC_TR and RTC_DR shadow registers.The HAL_RTC_WaitForSynchro() function
              implements the above software sequence (RSF clear and RSF check).
 
 @endverbatim
@@ -190,7 +190,7 @@ HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
   assert_param(IS_RTC_OUTPUT_REMAP(hrtc->Init.OutPutRemap));
   assert_param(IS_RTC_OUTPUT_POL(hrtc->Init.OutPutPolarity));
   assert_param(IS_RTC_OUTPUT_TYPE(hrtc->Init.OutPutType));
-  
+
   if(hrtc->State == HAL_RTC_STATE_RESET)
   {
     /* Allocate lock resource and initialize it */
@@ -325,7 +325,7 @@ HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
       if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
       {
         /* Enable the write protection for RTC registers */
-        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);  
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
         hrtc->State = HAL_RTC_STATE_ERROR;
 
@@ -341,7 +341,7 @@ HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
   HAL_RTC_MspDeInit(hrtc);
 
   hrtc->State = HAL_RTC_STATE_RESET;
-  
+
   /* Release Lock */
   __HAL_UNLOCK(hrtc);
 
@@ -350,7 +350,7 @@ HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
 
 /**
   * @brief  Initialize the RTC MSP.
-  * @param  hrtc: RTC handle  
+  * @param  hrtc: RTC handle
   * @retval None
   */
 __weak void HAL_RTC_MspInit(RTC_HandleTypeDef* hrtc)
@@ -360,12 +360,12 @@ __weak void HAL_RTC_MspInit(RTC_HandleTypeDef* hrtc)
 
   /* NOTE : This function should not be modified, when the callback is needed,
             the HAL_RTC_MspInit could be implemented in the user file
-   */ 
+   */
 }
 
 /**
   * @brief  DeInitialize the RTC MSP.
-  * @param  hrtc: RTC handle 
+  * @param  hrtc: RTC handle
   * @retval None
   */
 __weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
@@ -375,7 +375,7 @@ __weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
 
   /* NOTE : This function should not be modified, when the callback is needed,
             the HAL_RTC_MspDeInit could be implemented in the user file
-   */ 
+   */
 }
 
 /**
@@ -389,7 +389,7 @@ __weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
  ===============================================================================
                  ##### RTC Time and Date functions #####
  ===============================================================================
- 
+
  [..] This section provides functions allowing to configure Time and Date features
 
 @endverbatim
@@ -402,7 +402,7 @@ __weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
   * @param  sTime: Pointer to Time structure
   * @param  Format: Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
-  *            @arg RTC_FORMAT_BIN: Binary data format 
+  *            @arg RTC_FORMAT_BIN: Binary data format
   *            @arg RTC_FORMAT_BCD: BCD data format
   * @retval HAL status
   */
@@ -415,7 +415,7 @@ HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
   assert_param(IS_RTC_DAYLIGHT_SAVING(sTime->DayLightSaving));
   assert_param(IS_RTC_STORE_OPERATION(sTime->StoreOperation));
 
-  /* Process Locked */ 
+  /* Process Locked */
   __HAL_LOCK(hrtc);
 
   hrtc->State = HAL_RTC_STATE_BUSY;
@@ -473,7 +473,7 @@ HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
     /* Set RTC state */
     hrtc->State = HAL_RTC_STATE_ERROR;
 
-    /* Process Unlocked */ 
+    /* Process Unlocked */
     __HAL_UNLOCK(hrtc);
 
     return HAL_ERROR;
@@ -502,7 +502,7 @@ HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
 
         hrtc->State = HAL_RTC_STATE_ERROR;
 
-        /* Process Unlocked */ 
+        /* Process Unlocked */
         __HAL_UNLOCK(hrtc);
 
         return HAL_ERROR;
@@ -511,10 +511,10 @@ HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
 
     /* Enable the write protection for RTC registers */
     __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-    
+
    hrtc->State = HAL_RTC_STATE_READY;
 
-   __HAL_UNLOCK(hrtc); 
+   __HAL_UNLOCK(hrtc);
 
    return HAL_OK;
   }
@@ -523,19 +523,19 @@ HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
 /**
   * @brief  Get RTC current time.
   * @param  hrtc: RTC handle
-  * @param  sTime: Pointer to Time structure with Hours, Minutes and Seconds fields returned 
+  * @param  sTime: Pointer to Time structure with Hours, Minutes and Seconds fields returned
   *                with input format (BIN or BCD), also SubSeconds field returning the
   *                RTC_SSR register content and SecondFraction field the Synchronous pre-scaler
   *                factor to be used for second fraction ratio computation.
   * @param  Format: Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
-  *            @arg RTC_FORMAT_BIN: Binary data format 
+  *            @arg RTC_FORMAT_BIN: Binary data format
   *            @arg RTC_FORMAT_BCD: BCD data format
   * @note  You can use SubSeconds and SecondFraction (sTime structure fields returned) to convert SubSeconds
   *        value in second fraction ratio with time unit following generic formula:
   *        Second fraction ratio * time_unit= [(SecondFraction-SubSeconds)/(SecondFraction+1)] * time_unit
   *        This conversion can be performed only if no shift operation is pending (ie. SHFP=0) when PREDIV_S >= SS
-  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the values 
+  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the values
   *        in the higher-order calendar shadow registers to ensure consistency between the time and date values.
   *        Reading RTC current time locks the values in calendar shadow registers until Current date is read
   *        to ensure consistency between the time and date values.
@@ -553,7 +553,7 @@ HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
 
   /* Get SecondFraction structure field from the corresponding register field*/
   sTime->SecondFraction = (uint32_t)(hrtc->Instance->PRER & RTC_PRER_PREDIV_S);
-  
+
   /* Get the TR register */
   tmpreg = (uint32_t)(hrtc->Instance->TR & RTC_TR_RESERVED_MASK);
 
@@ -581,7 +581,7 @@ HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
   * @param  sDate: Pointer to date structure
   * @param  Format: specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
-  *            @arg RTC_FORMAT_BIN: Binary data format 
+  *            @arg RTC_FORMAT_BIN: Binary data format
   *            @arg RTC_FORMAT_BCD: BCD data format
   * @retval HAL status
   */
@@ -641,7 +641,7 @@ HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
     /* Set RTC state*/
     hrtc->State = HAL_RTC_STATE_ERROR;
 
-    /* Process Unlocked */ 
+    /* Process Unlocked */
     __HAL_UNLOCK(hrtc);
 
     return HAL_ERROR;
@@ -660,11 +660,11 @@ HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
       if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
       {
         /* Enable the write protection for RTC registers */
-        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);  
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
         hrtc->State = HAL_RTC_STATE_ERROR;
 
-        /* Process Unlocked */ 
+        /* Process Unlocked */
         __HAL_UNLOCK(hrtc);
 
         return HAL_ERROR;
@@ -676,7 +676,7 @@ HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
 
     hrtc->State = HAL_RTC_STATE_READY ;
 
-    /* Process Unlocked */ 
+    /* Process Unlocked */
     __HAL_UNLOCK(hrtc);
 
     return HAL_OK;
@@ -689,9 +689,9 @@ HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
   * @param  sDate: Pointer to Date structure
   * @param  Format: Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
-  *            @arg RTC_FORMAT_BIN:  Binary data format 
+  *            @arg RTC_FORMAT_BIN:  Binary data format
   *            @arg RTC_FORMAT_BCD:  BCD data format
-  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the values 
+  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the values
   *        in the higher-order calendar shadow registers to ensure consistency between the time and date values.
   *        Reading RTC current time locks the values in calendar shadow registers until Current date is read.
   * @retval HAL status
@@ -710,7 +710,7 @@ HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
   sDate->Year = (uint8_t)((datetmpreg & (RTC_DR_YT | RTC_DR_YU)) >> 16U);
   sDate->Month = (uint8_t)((datetmpreg & (RTC_DR_MT | RTC_DR_MU)) >> 8U);
   sDate->Date = (uint8_t)(datetmpreg & (RTC_DR_DT | RTC_DR_DU));
-  sDate->WeekDay = (uint8_t)((datetmpreg & (RTC_DR_WDU)) >> 13U); 
+  sDate->WeekDay = (uint8_t)((datetmpreg & (RTC_DR_WDU)) >> 13U);
 
   /* Check the input parameters format */
   if(Format == RTC_FORMAT_BIN)
@@ -730,11 +730,11 @@ HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
 /** @addtogroup RTC_Exported_Functions_Group3
  *  @brief   RTC Alarm functions
  *
-@verbatim   
+@verbatim
  ===============================================================================
                  ##### RTC Alarm functions #####
- ===============================================================================  
- 
+ ===============================================================================
+
  [..] This section provides functions allowing to configure Alarm feature
 
 @endverbatim
@@ -746,7 +746,7 @@ HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
   * @param  sAlarm: Pointer to Alarm structure
   * @param  Format: Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
-  *             @arg RTC_FORMAT_BIN: Binary data format 
+  *             @arg RTC_FORMAT_BIN: Binary data format
   *             @arg RTC_FORMAT_BCD: BCD data format
   * @retval HAL status
   */
@@ -834,7 +834,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
               ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16U) | \
               ((uint32_t)(sAlarm->AlarmDateWeekDay) << 24U) | \
               ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
-              ((uint32_t)sAlarm->AlarmMask));   
+              ((uint32_t)sAlarm->AlarmMask));
   }
 
   /* Configure the Alarm A or Alarm B Sub Second registers */
@@ -860,10 +860,10 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-        
+
         hrtc->State = HAL_RTC_STATE_TIMEOUT;
 
-        /* Process Unlocked */ 
+        /* Process Unlocked */
         __HAL_UNLOCK(hrtc);
 
         return HAL_TIMEOUT;
@@ -927,11 +927,11 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
   * @param  sAlarm: Pointer to Alarm structure
   * @param  Format: Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
-  *             @arg RTC_FORMAT_BIN: Binary data format 
+  *             @arg RTC_FORMAT_BIN: Binary data format
   *             @arg RTC_FORMAT_BCD: BCD data format
   * @note   The Alarm register can only be written when the corresponding Alarm
-  *         is disabled (Use the HAL_RTC_DeactivateAlarm()).   
-  * @note   The HAL_RTC_SetTime() must be called before enabling the Alarm feature.   
+  *         is disabled (Use the HAL_RTC_DeactivateAlarm()).
+  * @note   The HAL_RTC_SetTime() must be called before enabling the Alarm feature.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
@@ -947,7 +947,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
   assert_param(IS_RTC_ALARM_SUB_SECOND_VALUE(sAlarm->AlarmTime.SubSeconds));
   assert_param(IS_RTC_ALARM_SUB_SECOND_MASK(sAlarm->AlarmSubSecondMask));
 
-  /* Process Locked */ 
+  /* Process Locked */
   __HAL_LOCK(hrtc);
 
   hrtc->State = HAL_RTC_STATE_BUSY;
@@ -990,7 +990,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
       tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
       assert_param(IS_RTC_HOUR12(tmpreg));
       assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
-    } 
+    }
     else
     {
       sAlarm->AlarmTime.TimeFormat = 0x00U;
@@ -999,7 +999,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
 
     assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes)));
     assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds)));
-    
+
     if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
     {
       tmpreg = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
@@ -1016,7 +1016,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
               ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16U) | \
               ((uint32_t)(sAlarm->AlarmDateWeekDay) << 24U) | \
               ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
-              ((uint32_t)sAlarm->AlarmMask));     
+              ((uint32_t)sAlarm->AlarmMask));
   }
   /* Configure the Alarm A or Alarm B Sub Second registers */
   subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | (uint32_t)(sAlarm->AlarmSubSecondMask));
@@ -1029,7 +1029,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
   {
     /* Disable the Alarm A interrupt */
     __HAL_RTC_ALARMA_DISABLE(hrtc);
-    
+
     /* Clear flag alarm A */
     __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
 
@@ -1042,7 +1042,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
-        hrtc->State = HAL_RTC_STATE_TIMEOUT; 
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
 
         /* Process Unlocked */
         __HAL_UNLOCK(hrtc);
@@ -1063,7 +1063,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
   {
     /* Disable the Alarm B interrupt */
     __HAL_RTC_ALARMB_DISABLE(hrtc);
-    
+
     /* Clear flag alarm B */
     __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
 
@@ -1102,7 +1102,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
-  hrtc->State = HAL_RTC_STATE_READY; 
+  hrtc->State = HAL_RTC_STATE_READY;
 
   /* Process Unlocked */
   __HAL_UNLOCK(hrtc);
@@ -1196,7 +1196,7 @@ HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alar
   /* Process Unlocked */
   __HAL_UNLOCK(hrtc);
 
-  return HAL_OK; 
+  return HAL_OK;
 }
 
 /**
@@ -1206,10 +1206,10 @@ HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alar
   * @param  Alarm: Specifies the Alarm.
   *          This parameter can be one of the following values:
   *             @arg RTC_ALARM_A: AlarmA
-  *             @arg RTC_ALARM_B: AlarmB  
+  *             @arg RTC_ALARM_B: AlarmB
   * @param  Format: Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
-  *             @arg RTC_FORMAT_BIN: Binary data format 
+  *             @arg RTC_FORMAT_BIN: Binary data format
   *             @arg RTC_FORMAT_BCD: BCD data format
   * @retval HAL status
   */
@@ -1245,7 +1245,7 @@ HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
 
     tmpreg = (uint32_t)(hrtc->Instance->ALRMBR);
     subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMBSSR) & RTC_ALRMBSSR_SS);
- 
+
   /* Fill the structure with the read parameters */
   sAlarm->AlarmTime.Hours = (uint32_t)((tmpreg & (RTC_ALRMBR_HT | RTC_ALRMBR_HU)) >> 16U);
   sAlarm->AlarmTime.Minutes = (uint32_t)((tmpreg & (RTC_ALRMBR_MNT | RTC_ALRMBR_MNU)) >> 8U);
@@ -1256,7 +1256,7 @@ HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
   sAlarm->AlarmDateWeekDaySel = (uint32_t)(tmpreg & RTC_ALRMBR_WDSEL);
   sAlarm->AlarmMask = (uint32_t)(tmpreg & RTC_ALARMMASK_ALL);
  }
- 
+
   if(Format == RTC_FORMAT_BIN)
   {
     sAlarm->AlarmTime.Hours = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
@@ -1334,8 +1334,8 @@ __weak void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
 HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
 {
 
-  uint32_t tickstart = HAL_GetTick();   
-  
+  uint32_t tickstart = HAL_GetTick();
+
   while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) == RESET)
   {
     if(Timeout != HAL_MAX_DELAY)
@@ -1362,7 +1362,7 @@ HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t T
   */
 
 /** @addtogroup RTC_Exported_Functions_Group4
- *  @brief   Peripheral Control functions 
+ *  @brief   Peripheral Control functions
  *
 @verbatim
  ===============================================================================
@@ -1379,9 +1379,9 @@ HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t T
 /**
   * @brief  Wait until the RTC Time and Date registers (RTC_TR and RTC_DR) are
   *         synchronized with RTC APB clock.
-  * @note   The RTC Resynchronization mode is write protected, use the 
+  * @note   The RTC Resynchronization mode is write protected, use the
   *         __HAL_RTC_WRITEPROTECTION_DISABLE() before calling this function.
-  * @note   To read the calendar through the shadow registers after Calendar 
+  * @note   To read the calendar through the shadow registers after Calendar
   *         initialization, calendar update or after wakeup from low power modes
   *         the software must first clear the RSF flag.
   *         The software must then wait until it is set again before reading
@@ -1416,12 +1416,12 @@ HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc)
   */
 
 /** @addtogroup RTC_Exported_Functions_Group5
- *  @brief   Peripheral State functions 
+ *  @brief   Peripheral State functions
  *
-@verbatim   
+@verbatim
  ===============================================================================
                      ##### Peripheral State functions #####
- ===============================================================================  
+ ===============================================================================
     [..]
     This subsection provides functions allowing to
       (+) Get RTC state


### PR DESCRIPTION
Careful review and test revealed that we needed to rework the power management and RTC routines a bit, to manage the clock enables and the DBP bit.

This patch does not enable ULP mode during STANDBY, but .. we're not going to use Standby right now, so it's not very important. Further power reduction will focus on STOP mode.
