### PR TITLE
Fix #92 (Catena 4630 USB unstable issue fix)

### DIFF
--- a/variants/CATENA_4630/usb/usbd_conf.c
+++ b/variants/CATENA_4630/usb/usbd_conf.c
@@ -588,7 +588,7 @@ USBD_LL_ConnectionState_WEAK uint32_t USBD_LL_ConnectionState(void)
 {
   uint32_t vBus;
 
-  vBus = analogRead(18);
+  vBus = analogRead(16);
   return vBus > 250 ? 1 : 0;
 }
 


### PR DESCRIPTION
Properly match the VBUS detection pin Catena 4630's get USB Connection State function. It fixes USB unstable issue.