### PR TITLE
Fix #122: set -g flag to allow source-level debugging

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -37,11 +37,11 @@ compiler.suffix.cmd.windows=dfu-suffix.exe
 
 compiler.extra_flags=-mcpu={build.mcu} -mthumb @{build.opt.path}
 
-compiler.S.flags={compiler.extra_flags} -c -x assembler-with-cpp {compiler.stm.extra_include}
+compiler.S.flags={compiler.extra_flags} -c -g -x assembler-with-cpp {compiler.stm.extra_include}
 
-compiler.c.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -Dprintf=iprintf -MMD {compiler.stm.extra_include}
+compiler.c.flags={compiler.extra_flags} -c -g {build.flags.optimize} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -Dprintf=iprintf -MMD {compiler.stm.extra_include}
 
-compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {compiler.warning_flags} -std={compiler.cpp.std} -ffunction-sections -fdata-sections -nostdlib -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD {compiler.stm.extra_include}
+compiler.cpp.flags={compiler.extra_flags} -c -g {build.flags.optimize} {compiler.warning_flags} -std={compiler.cpp.std} -ffunction-sections -fdata-sections -nostdlib -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD {compiler.stm.extra_include}
 
 compiler.ar.flags=rcs
 


### PR DESCRIPTION
Compile with `-g` flag to allow source-level debugging.