### PR TITLE
Added Additional Pin Definitions for sx1276 Radio

### DIFF
--- a/variants/CATENA_4551/variant.h
+++ b/variants/CATENA_4551/variant.h
@@ -99,6 +99,11 @@ enum {
 #define RADIO_MISO              D3
 #define RADIO_SCK               D4
 #define RADIO_RESET             D8
+#define RADIO_TCXO              D33
+#define RADIO_DIO_0             D25 
+#define RADIO_DIO_1             D26 
+#define RADIO_DIO_2             D27 
+#define RADIO_DIO_3             D28
 
 #define FLASH_SS                D19
 #define FLASH_MOSI              D23

--- a/variants/CATENA_4551/variant.h
+++ b/variants/CATENA_4551/variant.h
@@ -99,7 +99,6 @@ enum {
 #define RADIO_MISO              D3
 #define RADIO_SCK               D4
 #define RADIO_RESET             D8
-#define RADIO_TCXO              D33
 #define RADIO_DIO_0             D25 
 #define RADIO_DIO_1             D26 
 #define RADIO_DIO_2             D27 

--- a/variants/CATENA_461x/variant.cpp
+++ b/variants/CATENA_461x/variant.cpp
@@ -62,7 +62,7 @@ const PinName digitalPin[] = {
   PC_1,  //D30/A16 RADIO_ANT_SWITCH_TX_BOOST CRF3
   PC_2,  //D31/A17 RADIO_ANT_SWITCH_TX_RFO   CRF2
   NC,    //D32     Flash Write-Protect (not supported these platforms)
-  PA_8,  //D33
+  PA_8,  //D33     RADIO_TCXO
 };
 
 #ifdef __cplusplus

--- a/variants/CATENA_461x/variant.h
+++ b/variants/CATENA_461x/variant.h
@@ -99,6 +99,11 @@ enum {
 #define RADIO_MISO              D3
 #define RADIO_SCK               D4
 #define RADIO_RESET             D8
+#define RADIO_TCXO              D33
+#define RADIO_DIO_0             D25 
+#define RADIO_DIO_1             D26 
+#define RADIO_DIO_2             D27 
+#define RADIO_DIO_3             D28 
 
 #define FLASH_SS                D19
 #define FLASH_MOSI              D23

--- a/variants/CATENA_4630/variant.cpp
+++ b/variants/CATENA_4630/variant.cpp
@@ -62,7 +62,7 @@ const PinName digitalPin[] = {
   PC_1,  //D30/A16 RADIO_ANT_SWITCH_TX_BOOST CRF3
   PC_2,  //D31/A17 RADIO_ANT_SWITCH_TX_RFO   CRF2
   NC,    //D32     Flash Write-Protect (not supported these platforms)
-  PA_8,  //D33     TCXO_Supply_control_ON_OFF
+  PA_8,  //D33     RADIO_TXCO    TCXO_Supply_control_ON_OFF
 };
 
 #ifdef __cplusplus

--- a/variants/CATENA_4630/variant.h
+++ b/variants/CATENA_4630/variant.h
@@ -99,6 +99,11 @@ enum {
 #define RADIO_MISO              D3
 #define RADIO_SCK               D4
 #define RADIO_RESET             D8
+#define RADIO_TCXO              D33
+#define RADIO_DIO_0             D25 
+#define RADIO_DIO_1             D26 
+#define RADIO_DIO_2             D27 
+#define RADIO_DIO_3             D28
 
 #define FLASH_SS                D19
 #define FLASH_MOSI              D23

--- a/variants/CATENA_4801/variant.cpp
+++ b/variants/CATENA_4801/variant.cpp
@@ -62,7 +62,7 @@ const PinName digitalPin[] = {
   PC_1,  //D30/A16 RADIO_ANT_SWITCH_TX_BOOST CRF3
   PC_2,  //D31/A17 RADIO_ANT_SWITCH_TX_RFO   CRF2
   NC,    //D32     Flash Write-Protect (not supported these platforms)
-  PA_8,  //D33     TCXO VDD, possibly VDD boost enable.
+  PA_8,  //D33     RADIO_TCXO      TCXO VDD, possibly VDD boost enable.
 };
 
 #ifdef __cplusplus

--- a/variants/CATENA_4801/variant.h
+++ b/variants/CATENA_4801/variant.h
@@ -99,6 +99,11 @@ enum {
 #define RADIO_MISO              D3
 #define RADIO_SCK               D4
 #define RADIO_RESET             D8
+#define RADIO_TCXO              D33
+#define RADIO_DIO_0             D25 
+#define RADIO_DIO_1             D26 
+#define RADIO_DIO_2             D27 
+#define RADIO_DIO_3             D28
 
 #define FLASH_SS                D19
 #define FLASH_MOSI              D23


### PR DESCRIPTION
This PR adds additional pin definitions for the sx1276 radio in the Murata CMWX1ZZABZ-078 module.

I am using the Semtech drivers directly, and not using the MCCI LoRaWAN implementations, so having these definitions helps my pin readability considerably!

-Kent