### PR TITLE
Fix USB-based hot-interrupt hang

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -52,7 +52,7 @@
 ///     \ref _mcci_arduino_version_calc() to compare relative versions.
 ///
 #define	_mcci_arduino_version	\
-  _mcci_arduino_version_calc(3, 0, 5, 1)	/* v3.0.5-pre1 */
+  _mcci_arduino_version_calc(3, 0, 5, 2)	/* v3.0.5-pre2 */
 
 ///
 /// \brief get major version code from semantic version value

--- a/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pcd.c
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pcd.c
@@ -190,7 +190,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
  hpcd->Instance->BTABLE = BTABLE_ADDRESS;
  
  /*set wInterrupt_Mask global variable*/
- wInterrupt_Mask = USB_CNTR_CTRM  | USB_CNTR_WKUPM | USB_CNTR_SUSPM | USB_CNTR_ERRM \
+ wInterrupt_Mask = USB_CNTR_CTRM  | USB_CNTR_WKUPM | USB_CNTR_SUSPM /* | USB_CNTR_ERRM */ \
    | USB_CNTR_SOFM | USB_CNTR_ESOFM | USB_CNTR_RESETM;
  
   /*Set interrupt mask*/
@@ -362,7 +362,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
     hpcd->Instance->CNTR &= (uint16_t) ~(USB_CNTR_LPMODE);
     
     /*set wInterrupt_Mask global variable*/
-    wInterrupt_Mask = USB_CNTR_CTRM  | USB_CNTR_WKUPM | USB_CNTR_SUSPM | USB_CNTR_ERRM \
+    wInterrupt_Mask = USB_CNTR_CTRM  | USB_CNTR_WKUPM | USB_CNTR_SUSPM /* | USB_CNTR_ERRM */ \
       | USB_CNTR_SOFM | USB_CNTR_ESOFM | USB_CNTR_RESETM;
 
     /*Set interrupt mask*/

--- a/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pcd.c
+++ b/system/Drivers/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pcd.c
@@ -353,7 +353,8 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
 
   if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_ERR))
   {
-    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_ERR); 
+    __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_ERR);
+    hpcd->Instance->CNTR &= ~USB_ISTR_ERR;
   }
 
   if (__HAL_PCD_GET_FLAG (hpcd, USB_ISTR_WKUP))


### PR DESCRIPTION
This request fixes #189/#190, in which a Catena 4612 board might hang when running from a USB charger or probably from battery, if configured to enable USB.